### PR TITLE
fix: make retry interval larger PS-496

### DIFF
--- a/src/Command/AlterWarehouse.php
+++ b/src/Command/AlterWarehouse.php
@@ -53,7 +53,7 @@ MAX_CONCURRENCY_LEVEL = %s;",
     public function executeAlter(): void
     {
         $retryPolicy = new SimpleRetryPolicy($this->retryAttempts);
-        $backOffPolicy = new ExponentialBackOffPolicy(10000);
+        $backOffPolicy = new ExponentialBackOffPolicy(60000);
 
         $proxy = new RetryProxy($retryPolicy, $backOffPolicy, $this->logger);
         $proxy->call(function (): void {

--- a/src/Command/AlterWarehouse.php
+++ b/src/Command/AlterWarehouse.php
@@ -53,7 +53,7 @@ MAX_CONCURRENCY_LEVEL = %s;",
     public function executeAlter(): void
     {
         $retryPolicy = new SimpleRetryPolicy($this->retryAttempts);
-        $backOffPolicy = new ExponentialBackOffPolicy(60000);
+        $backOffPolicy = new ExponentialBackOffPolicy(60000, null, 300000);
 
         $proxy = new RetryProxy($retryPolicy, $backOffPolicy, $this->logger);
         $proxy->call(function (): void {

--- a/src/Command/AlterWarehouse.php
+++ b/src/Command/AlterWarehouse.php
@@ -53,7 +53,7 @@ MAX_CONCURRENCY_LEVEL = %s;",
     public function executeAlter(): void
     {
         $retryPolicy = new SimpleRetryPolicy($this->retryAttempts);
-        $backOffPolicy = new ExponentialBackOffPolicy();
+        $backOffPolicy = new ExponentialBackOffPolicy(10000);
 
         $proxy = new RetryProxy($retryPolicy, $backOffPolicy, $this->logger);
         $proxy->call(function (): void {


### PR DESCRIPTION
Ze Snowflaku napsali, ze to ma interni retry kolem 5 minut https://community.snowflake.com/s/case/5003r00001JLw3EAAT/sql-execution-internal-error?tabset-5ba45500=2 - sice doporucuji zkusit to znovu az za 5minut, ale to se mi zda az moc - to bysme se taky nemuseli toho zvetseni dockat, takze jsem tam dal minutu. V kazdym pripade 100ms je moc malo.

https://keboola.atlassian.net/browse/PS-496