### PR TITLE
allow xsmall wh and max cluster count to min 1

### DIFF
--- a/src/ConfigDefinition.php
+++ b/src/ConfigDefinition.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 class ConfigDefinition extends BaseConfigDefinition
 {
 
-    private const POSSIBLE_WAREHOUSE_SIZES = ['SMALL', 'MEDIUM', 'LARGE'];
+    private const POSSIBLE_WAREHOUSE_SIZES = ['XSMALL', 'SMALL', 'MEDIUM', 'LARGE'];
 
     protected function getParametersDefinition(): ArrayNodeDefinition
     {
@@ -41,7 +41,7 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->end()
                 ->integerNode('max_cluster_count')
                     ->isRequired()
-                    ->min(3)
+                    ->min(1)
                 ->end()
                 ->integerNode('max_concurrency_level')
                     ->isRequired()

--- a/tests/phpunit/ConfigDefinitionTest.php
+++ b/tests/phpunit/ConfigDefinitionTest.php
@@ -44,7 +44,7 @@ class ConfigDefinitionTest extends TestCase
                 ['min_cluster_count' => 50],
             ],
             'too-small-max-count' => [
-                ['max_cluster_count' => 1],
+                ['max_cluster_count' => 0],
             ],
             'too-low-concurrency-level' => [
                 ['max_concurency_level' => 2],


### PR DESCRIPTION
prislo zo zendesku https://keboola.zendesk.com/agent/tickets/17241
```
I need the option to set max cluster count to 1 (currently 3 is minimum) and be able to set warehouse size to xsmall.
```
Nepytal som sa ako sa ktomu dostali ale tipujem ze to nebola nahoda kedze komponenta je private, imho im to poradil Padak.

Ak sa to mergne tak este upravim configuration schemu v
https://components.keboola.com/~/components/keboola.app-snowflake-happy-hour/edit

